### PR TITLE
Fix Payapp webhook supabase key

### DIFF
--- a/server.js
+++ b/server.js
@@ -73,7 +73,7 @@ app.post('/api/webhook/payapp', async (req, res) => {
 
             // Supabase를 통한 주문 정보 저장
             const supabaseUrl = process.env.SUPABASE_URL;
-            const supabaseKey = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_ANON_KEY;
+            const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
             
             if (supabaseUrl && supabaseKey) {
                 const { createClient } = require('@supabase/supabase-js');


### PR DESCRIPTION
## Summary
- fix Payapp webhook to use `SUPABASE_SERVICE_ROLE_KEY`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686da2bcb364832ebf5028928a2eaf99